### PR TITLE
Fix links where target has parenthesis

### DIFF
--- a/fix-links.sh
+++ b/fix-links.sh
@@ -25,7 +25,8 @@ echo "Fixing links in documents"
 
 function process_file {
     # Fix overview links
-    perl -pi -e 's~https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md~https://specs.amwa.tv/nmos/branches/master/NMOS_Technical_Overview.html~gi;' "$1" 
+    perl -pi -e 's~https://github.com/AMWA-TV/nmos/blob/master/NMOS%20Technical%20Overview.md~https://specs.amwa.tv/nmos/branches/main/NMOS_Technical_Overview.html~gi;' "$1" 
+
     # Change .raml links to .html
     perl -pi -e 's:\.raml\):.html\):g;' "$1"
 
@@ -38,25 +39,17 @@ function process_file {
     # Same but for reference links
     perl -ni -e '@parts = split /(\]:.*?\.md(?:#.*\b)?)/ ; for ($n = 1; $n < @parts; $n += 2) { $parts[$n] =~ s/%20/_/g; }; print @parts' "$1"
 
+    # Change .md links to .html
+    perl -pi -e 's:\.md\):.html\):g;' "$1"
+
     # Replace any copyright with blank line (because it is added in a footer)
     perl -pi -e 's:_\(c\) AMWA.*_$::' "$1"
 }
 
-# NMOS-PARAMETER-REGISTERS has individual dir for each register
-if [[ "$AMWA_ID" == "NMOS-PARAMETER-REGISTERS" ]]; then
-    for file in {branches,releases}/*/*/*.md index.md; do
-        process_file "$file"
-    done
-
-# Other repos have some or all of docs/, APIs/, examples/
-else
-    for file in {branches,releases}/*/docs/*.md; do
-        process_file "$file"
-    done
-fi
-
-
-
+for file in index.md {branches,releases}/index.md {branches,releases}/*/index.md {branches,releases}/*/docs/*.md; do
+    echo "$file"
+    process_file "$file"
+done
 
 # Special case: relative links that need to go to the repo not the pages
 if [[ "$AMWA_ID" == "NMOS-TESTING" ]]; then

--- a/fix-links.sh
+++ b/fix-links.sh
@@ -47,7 +47,6 @@ function process_file {
 }
 
 for file in index.md {branches,releases}/**/*.md; do
-    echo "$file"
     process_file "$file"
 done
 

--- a/fix-links.sh
+++ b/fix-links.sh
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
-# Copyright 2019 British Broadcasting Corporation
+# Copyright 2021 British Broadcasting Corporation
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -16,7 +16,7 @@
 
 set -o errexit
 
-shopt -s nullglob
+shopt -s globstar nullglob
 
 # shellcheck source=get-config.sh
 . .scripts/get-config.sh
@@ -46,7 +46,7 @@ function process_file {
     perl -pi -e 's:_\(c\) AMWA.*_$::' "$1"
 }
 
-for file in index.md {branches,releases}/index.md {branches,releases}/*/index.md {branches,releases}/*/docs/*.md; do
+for file in index.md {branches,releases}/**/*.md; do
     echo "$file"
     process_file "$file"
 done

--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -193,7 +193,7 @@ fi
 # Add the default links at the top - correct the links while copying text
 if [ "$DEFAULT_TREE" ]; then
     echo "Adding in contents of $INDEX for default tree $DEFAULT_TREE"
-    sed "s:(:($DEFAULT_TREE/:" "$DEFAULT_TREE/$INDEX" >> "$INDEX"
+    sed "s:](:]($DEFAULT_TREE/:" "$DEFAULT_TREE/$INDEX" >> "$INDEX"
 fi
 
 # TODO: DRY on the following...


### PR DESCRIPTION
nmos-authorization-implementation-guide has docs with parentheses in the file name. Jekyll etc don't handle those properly so now rewriting all .md extensions to .html.

Tested on nmos-authorization-implementation-guide, nmos-parameter-registers and nmos-template.