### PR TITLE
Added RewriteRule for repo redirect

### DIFF
--- a/make-rewrites.sh
+++ b/make-rewrites.sh
@@ -38,3 +38,5 @@ if [[ -d releases ]]; then
     done
 fi
 
+echo Making repo rule
+echo "RewriteRule ^repo/?$ $REPO_ADDRESS [R]" >> $HTACCESS

--- a/make-rewrites.sh
+++ b/make-rewrites.sh
@@ -38,5 +38,5 @@ if [[ -d releases ]]; then
     done
 fi
 
-echo Making repo rule
+echo Making repo rewrite rule
 echo "RewriteRule ^repo/?$ $REPO_ADDRESS [R]" >> $HTACCESS


### PR DESCRIPTION
Provides a convenience redirect e.g. https://specs.amwa.tv/is-04/repo -> https://github.com/AMWA-TV/nmos-discovery-registration.