### PR TITLE
Fix 403 error for link to schema index

### DIFF
--- a/fix-links.sh
+++ b/fix-links.sh
@@ -30,8 +30,8 @@ function process_file {
     # Change .raml links to .html
     perl -pi -e 's:\.raml\):.html\):g;' "$1"
 
-    # Change .json links to .html and use with-refs for schemas
-    perl -pi -e 's:\.json\):.html\):g; s:/APIs/schemas:/APIs/schemas/with-refs:g;' "$1"
+    # Change .json links to .html and use with-refs for schemas (but not for schema indexes)
+    perl -pi -e 's:\.json\):.html\):g; s:/APIs/schemas/([^)]+):/APIs/schemas/with-refs/$1:g;' "$1"
 
     # Change %20 escaped spaces in links to underscores. Allow for possible #target-in-page links.
     perl -ni -e '@parts = split /(\(.*?\.md(?:#.*\b)?\))/ ; for ($n = 1; $n < @parts; $n += 2) { $parts[$n] =~ s/%20/_/g; }; print @parts' "$1"


### PR DESCRIPTION
This should fix https://github.com/AMWA-TV/nmos-device-connection-management/issues/130

Links to the schema index (`.../schemas/`) should not have `with-refs` added.

Tested locally on nmos-template, including adding a test link that should be written