### PR TITLE
Latest release rewrites

### DIFF
--- a/fix-links.sh
+++ b/fix-links.sh
@@ -30,8 +30,8 @@ function process_file {
     # Change .raml links to .html
     perl -pi -e 's:\.raml\):.html\):g;' "$1"
 
-    # Change .json links to .html and use with-refs for schemas
-    perl -pi -e 's:\.json\):.html\):g; s:/APIs/schemas:/APIs/schemas/with-refs:g;' "$1"
+    # Change .json links to .html and use with-refs for schemas (but not for schema indexes)
+    perl -pi -e 's:\.json\):.html\):g; s:/APIs/schemas/([^)]+):/APIs/schemas/with-refs/$1:g;' "$1"
 
     # Change %20 escaped spaces in links to underscores. Allow for possible #target-in-page links.
     perl -ni -e '@parts = split /(\(.*?\.md(?:#.*\b)?\))/ ; for ($n = 1; $n < @parts; $n += 2) { $parts[$n] =~ s/%20/_/g; }; print @parts' "$1"

--- a/make-rewrites.sh
+++ b/make-rewrites.sh
@@ -30,12 +30,25 @@ fi
 
 if [[ -d releases ]]; then
     echo Making release rewrite rules
-    for t in releases/*; do
-        release=${t#*/}
+    for r in releases/*; do
+        release=${r#*/}
         if [[ -n "$SHOW_RELEASES" && "$release" =~ $SHOW_RELEASES ]]; then
             echo "RewriteRule ^$release(.*) releases/$release\$1" >> $HTACCESS
         fi
     done
+    echo Making latest release rewrite rules
+    find releases -maxdepth 1 -type d -name 'v*' | sort | sed s:releases/:: | awk -F. '
+{
+    latest[sprintf("%s.%s", $1, $2)] = $0
+}
+END {
+    for (v in latest) {
+        printf("RewriteRule ^%s(.*) releases/%s$1\n", v, latest[v])
+        overall_latest = latest[v]
+    }
+    printf("RewriteRule ^latest(.*) releases/%s$1\n", overall_latest)
+}
+' >> $HTACCESS
 fi
 
 echo Making repo rewrite rule


### PR DESCRIPTION
This adds rewrite rules to `.htaccess` to access most recent point release of a version, or the most recent release overall, i.e.:

`.../vX.Y` -> `.../releases/vX.Y.Z` with highest `Z`
`.../latest` -> `.../releases/vX.Y.Z` with highest `X.Y.Z`

Although it should still work with the "legacy" `v1.Y` release naming, do not merge until we have migrated those to `v1.Y.0`