### PR TITLE
Support markdown list of docs in links

### DIFF
--- a/extract-docs.sh
+++ b/extract-docs.sh
@@ -26,7 +26,7 @@ if [[ "$AMWA_ID" =~ "IS-" && ! -d node_modules/.bin ]]; then
     exit 1
 fi
 
-# Unfortunately bash doesn't have proper functions or scoping...
+# Unfortunately bash doesn't have proper functions or scoping
 function make_label {
     local label="${1%%.md}"
     label="${label//%20/ }"                   
@@ -87,12 +87,30 @@ function extract {
             (
                 cd docs || exit 1
 
-                if [ -f README.md ]; then
-                    echo "Using README.md for contents"
-                    mkdir "../../$target_dir/docs"
-                    prev_file=
-                    prev_link=
-                    prevprev_link=
+                mkdir "../../$target_dir/docs"
+                prev_file=
+                prev_link=
+                prevprev_link=
+
+                if compgen -G "[1-9].*.md" > /dev/null; then
+                    echo "Extracting numbered docs"
+
+                    for i in [1-9]*.md; do
+                        cp "$i" "../../$target_dir/docs"
+                        this_file="../../$target_dir/docs/$i"
+                        this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
+                        if [ -n "$prev_file" ]; then
+                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
+                        fi
+                        prevprev_link="$prev_link"
+                        prev_file="$this_file"
+                        prev_link="$this_link"
+                    done
+                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
+
+                elif [ -f README.md ]; then
+                    echo "Extracting docs from list in README.md"
+
                     while read -r i; do
                         filename="${i//%20/ }.md" # README.md links use %20 for spaces
                         cp "$filename" "../../$target_dir/docs"
@@ -107,63 +125,18 @@ function extract {
                     done <<< "$(awk -F'^ *- \\[.*\\]\\(' '(NF>1){print $2}' README.md | sed 's/.md)//')"
                     add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
 
-                   # Need to extract contents.md to make indexes later
-                   cp README.md "../../$target_dir/docs" 
+                    # Need to extract README.md to make indexes later
+                    cp README.md "../../$target_dir/docs"
 
-                    if [ -d images ] ; then
-                        cp -r images "../../$target_dir/docs" 
-                    fi               
-
-                elif [ -f contents.md ]; then
-                    echo "==== THIS CODE IS NOT IN USE ==="
-                    exit 1
-                    echo "Using contents.md for contents"
-                    mkdir "../../$target_dir/docs"
-                    prev_file=
-                    prev_link=
-                    prevprev_link=
-                    while read -r i; do
-                        cp "$i" "../../$target_dir/docs"
-                        this_file="../../$target_dir/docs/$i"
-                        this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
-                        if [ -n "$prev_file" ]; then
-                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
-                        fi
-                        prevprev_link="$prev_link"
-                        prev_file="$this_file"
-                        prev_link="$this_link"
-                    done <<< "$(awk  -F'^ *- ' '(NF>1){printf("%s.md\n", $2)}' contents.md)"
-                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
-
-                   # Need to extract contents.md to make indexes later
-                   cp contents.md "../../$target_dir/docs" 
-
-                    if [ -d images ] ; then
-                        cp -r images "../../$target_dir/docs" 
-                    fi
                 else
-                    echo "No contents.md found so using document numbers"
-                    mkdir "../../$target_dir/docs"
-                    prev_file=
-                    prev_link=
-                    prevprev_link=
-                    for i in [1-9]*.md; do
-                        cp "$i" "../../$target_dir/docs"
-                        this_file="../../$target_dir/docs/$i"
-                        this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
-                        if [ -n "$prev_file" ]; then
-                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
-                        fi
-                        prevprev_link="$prev_link"
-                        prev_file="$this_file"
-                        prev_link="$this_link"
-                    done
-                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
-
-                    if [ -d images ] ; then
-                        cp -r images "../../$target_dir/docs" 
-                    fi
+                    echo No numbered docs or README.md found
+                    exit 1
                 fi
+
+                if [ -d images ] ; then
+                    cp -r images "../../$target_dir/docs" 
+                fi
+
             )
             fi
 
@@ -172,9 +145,9 @@ function extract {
                 cd APIs || exit 1
                 (
                     cd schemas || exit 1
+                    echo "Resolving schema references"
                     mkdir with-refs resolved
                     for i in *.json; do
-                        echo "Resolving schema references for $i"
                         if ! resolve-schema.py "$i" > "resolved/$i" ; then
                             echo "WARNING: Resolving failed: resolved/$i may include \$refs"
                             cp "$i" "resolved/$i"
@@ -185,7 +158,7 @@ function extract {
                 )
                 for i in *.raml; do
                     HTML_API=${i%%.raml}.html
-                    echo "Generating $HTML_API from $i..."
+                    echo "Generating $HTML_API from $i"
                     cat << EOF > "$HTML_API"
 ---
 layout: default
@@ -207,19 +180,17 @@ EOF
                 cp ../../.scripts/json-formatter.js "../../$target_dir/APIs/"
 
                 if [ -d schemas ]; then
-                    echo "Rendering with-refs schemas..."
+                    echo "Rendering with-refs schemas"
                     for i in schemas/with-refs/*.json; do
                         HTML_SCHEMA=${i%%.json}.html
-                        # echo "Generating $HTML_SCHEMA from $i..."
                         render-json.sh -n "$i" "Schema ${i##*/}" "../../${HTML_SCHEMA/with-refs/resolved}" "Resolve referenced schemas (may reorder keys)" > "$HTML_SCHEMA"
                     done
-                    echo "Rendering resolved schemas..."
+                    echo "Rendering resolved schemas"
                     for i in schemas/resolved/*.json; do
                         HTML_SCHEMA=${i%%.json}.html
-                        # echo "Generating $HTML_SCHEMA from $i..."
                         render-json.sh "$i" "Schema ${i##*/}" "../../${HTML_SCHEMA/resolved/with-refs}" "Show original (referenced schemas with \$ref)" > "$HTML_SCHEMA"
                     done
-                    echo "Moving schemas..."
+                    echo "Moving schemas"
                     mkdir "../../$target_dir/APIs/schemas"
                     mkdir "../../$target_dir/APIs/schemas/with-refs"
                     cp ../../.scripts/json-formatter.js "../../$target_dir/APIs/schemas/with-refs"
@@ -233,7 +204,7 @@ EOF
                     for i in schemas/resolved/*.html; do
                         mv "$i" "../../$target_dir/APIs/schemas/resolved"
                     done
-                    echo "Tidying..."
+                    echo "Tidying"
                     # Restore things how they were to ensure next checkout doesn't overwrite
                     for i in schemas/with-refs/*.json; do
                         mv "$i" schemas/ 
@@ -244,15 +215,14 @@ EOF
             fi
             if [ -d examples ]; then
             (
-                echo "Rendering examples..."
+                echo "Rendering examples"
                 cd examples || exit 1
                     for i in **/*.json; do
                         flat=${i//*\//}
                         HTML_EXAMPLE=${flat%%.json}.html 
-                        echo "Rendering $HTML_EXAMPLE from $i..." 
                         render-json.sh -n "$i" "Example ${i##*/}" >> "$HTML_EXAMPLE"
                     done
-                    echo "Moving examples..."
+                    echo "Moving examples"
                     mkdir "../../$target_dir/examples"
                     for i in *.html; do
                         mv "$i" "../../$target_dir/examples"

--- a/extract-docs.sh
+++ b/extract-docs.sh
@@ -87,7 +87,36 @@ function extract {
             (
                 cd docs || exit 1
 
-                if [ -f contents.md ]; then
+                if [ -f README.md ]; then
+                    echo "Using README.md for contents"
+                    mkdir "../../$target_dir/docs"
+                    prev_file=
+                    prev_link=
+                    prevprev_link=
+                    while read -r i; do
+                        filename="${i//%20/ }.md" # README.md links use %20 for spaces
+                        cp "$filename" "../../$target_dir/docs"
+                        this_file="../../$target_dir/docs/$filename"
+                        this_link="${filename// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
+                        if [ -n "$prev_file" ]; then
+                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
+                        fi
+                        prevprev_link="$prev_link"
+                        prev_file="$this_file"
+                        prev_link="$this_link"
+                    done <<< "$(awk -F'^ *- \\[.*\\]\\(' '(NF>1){print $2}' README.md | sed 's/.md)//')"
+                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
+
+                   # Need to extract contents.md to make indexes later
+                   cp README.md "../../$target_dir/docs" 
+
+                    if [ -d images ] ; then
+                        cp -r images "../../$target_dir/docs" 
+                    fi               
+
+                elif [ -f contents.md ]; then
+                    echo "==== THIS CODE IS NOT IN USE ==="
+                    exit 1
                     echo "Using contents.md for contents"
                     mkdir "../../$target_dir/docs"
                     prev_file=

--- a/extract-docs.sh
+++ b/extract-docs.sh
@@ -79,30 +79,61 @@ function extract {
                     cp -r ../.scripts/codemirror "../$target_dir/${json%/*.json}/"
                 done
 
+
+
         # Other repos have some or all of docs/, APIs/, examples/
         else
             if [ -d docs ]; then
             (
                 cd docs || exit 1
-                mkdir "../../$target_dir/docs"
-                prev_file=
-                prev_link=
-                prevprev_link=
-                for i in [1-9]*.md; do
-                    cp "$i" "../../$target_dir/docs"
-                    this_file="../../$target_dir/docs/$i"
-                    this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
-                    if [ -n "$prev_file" ]; then
-                        add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
-                    fi
-                    prevprev_link="$prev_link"
-                    prev_file="$this_file"
-                    prev_link="$this_link"
-                done
-                add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
 
-                if [ -d images ] ; then
-                    cp -r images "../../$target_dir/docs" 
+                if [ -f contents.md ]; then
+                    echo "Using contents.md for contents"
+                    mkdir "../../$target_dir/docs"
+                    prev_file=
+                    prev_link=
+                    prevprev_link=
+                    while read -r i; do
+                        cp "$i" "../../$target_dir/docs"
+                        this_file="../../$target_dir/docs/$i"
+                        this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
+                        if [ -n "$prev_file" ]; then
+                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
+                        fi
+                        prevprev_link="$prev_link"
+                        prev_file="$this_file"
+                        prev_link="$this_link"
+                    done <<< "$(awk  -F'^ *- ' '(NF>1){printf("%s.md\n", $2)}' contents.md)"
+                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
+
+                   # Need to extract contents.md to make indexes later
+                   cp contents.md "../../$target_dir/docs" 
+
+                    if [ -d images ] ; then
+                        cp -r images "../../$target_dir/docs" 
+                    fi
+                else
+                    echo "No contents.md found so using document numbers"
+                    mkdir "../../$target_dir/docs"
+                    prev_file=
+                    prev_link=
+                    prevprev_link=
+                    for i in [1-9]*.md; do
+                        cp "$i" "../../$target_dir/docs"
+                        this_file="../../$target_dir/docs/$i"
+                        this_link="${i// /%20}" # so links look like they do on github.com -- fixlinks.sh converts to underscore
+                        if [ -n "$prev_file" ]; then
+                            add_nav_links "$prevprev_link" "$this_link" "$prev_file" 
+                        fi
+                        prevprev_link="$prev_link"
+                        prev_file="$this_file"
+                        prev_link="$this_link"
+                    done
+                    add_nav_links "$prevprev_link" "" "$this_file" # Last one has no next; singleton has no previous either
+
+                    if [ -d images ] ; then
+                        cp -r images "../../$target_dir/docs" 
+                    fi
                 fi
             )
             fi

--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -52,7 +52,8 @@ function add_docs_from_markdown_list {
 
     # Rename to use underscores instead of spaces
     while read -r doc; do
-        mv "docs/$doc" "docs/${doc// /_}"
+        underscore_space_doc="${doc// /_}"
+        [[ "$underscore_space_doc" != "$doc" ]] && mv "$doc" "$underscore_space_doc"
     done <<< "$(awk  -F'^ *- ' '(NF>1){printf("%s.md\n", $2)}' $list)"
 
     # Create a link with spaces in target converted to underscores

--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -107,7 +107,7 @@ function do_tree {
                         done
                     fi
 
-                # Other repos may have numbered docs/, APIs/, APIs/schemas/, examples/
+                # Other repos may have unnumbered docs/, APIs/, APIs/schemas/, examples/
                 else
                     if [[ "$label" == "branch" && "$dirname" == "main" ]]; then
                         # avoid "...for branch main" in repos where that might cause confusion
@@ -119,8 +119,8 @@ function do_tree {
                         INDEX_DOCS="docs/$INDEX"
                         echo -e "\n## Documentation $tree_text\n" >> "$INDEX"
                         echo -e "## Documentation $tree_text\n" >> "$INDEX_DOCS"
-                        for doc in docs/[1-9]*.md; do
-                            add_numbered_doc "$doc"
+                        for doc in docs/*.md; do
+                            add_unnumbered_doc "$doc"
                         done
                     fi
 

--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -142,17 +142,19 @@ function do_tree {
                         INDEX_DOCS="docs/$INDEX"
                         echo -e "\n## Documentation $tree_text\n" >> "$INDEX"
                         echo -e "## Documentation $tree_text\n" > "$INDEX_DOCS"
-                        if [ -f docs/README.md ] ; then
-                            echo Adding docs/README.md
-                            add_docs_from_markdown_list_of_links docs/README.md
-                        elif [ -f docs/contents.md ] ; then
-                            echo Adding docs/contents.md
-                            add_docs_from_markdown_list docs/contents.md
-                        else
-                            echo "No contents.md so using numbers"
+
+
+                        if compgen -G "docs/[1-9].*.md" > /dev/null ; then
+                            echo "Adding numbered docs"
                             for doc in docs/*.md; do
                                 add_numbered_doc "$doc"
                             done
+                        elif [ -f docs/README.md ] ; then
+                            echo Adding docs from list in README.md
+                            add_docs_from_markdown_list_of_links docs/README.md
+                        else
+                            echo No numbered docs or README.md found
+                            exit 1
                         fi
                     fi
 
@@ -233,7 +235,7 @@ fi
 
 # These excluded repos don't have branch and releases indexes
 if [[ ! "$AMWA_ID" == "SPECS" && ! "$AMWA_ID" == "NMOS" && ! "$AMWA_ID" == "BCP-002" && ! "$AMWA_ID" == "BCP-003" ]]; then
-    echo Adding releases index...
+    echo Adding releases index
     INDEX_RELEASES="releases/index.md"
     echo "## Published Releases" > "$INDEX_RELEASES"
     echo -e "\n##  Published Releases" >> "$INDEX"
@@ -243,7 +245,7 @@ if [[ ! "$AMWA_ID" == "SPECS" && ! "$AMWA_ID" == "NMOS" && ! "$AMWA_ID" == "BCP-
         echo -e "\n[$release]($release/)" >>  "$INDEX_RELEASES"
     done
 
-    echo Adding branches index...
+    echo Adding branches index
     INDEX_BRANCHES="branches/index.md"
     echo "## Live Branches" > "$INDEX_BRANCHES"
     echo -e "\n## Live Branches" >> "$INDEX"

--- a/make-indexes.sh
+++ b/make-indexes.sh
@@ -53,7 +53,7 @@ function add_docs_from_markdown_list {
     # Rename to use underscores instead of spaces
     while read -r doc; do
         underscore_space_doc="${doc// /_}"
-        [[ "$underscore_space_doc" != "$doc" ]] && mv "$doc" "$underscore_space_doc"
+        [[ "$underscore_space_doc" != "$doc" ]] && mv "docs/$doc" "docs/$underscore_space_doc"
     done <<< "$(awk  -F'^ *- ' '(NF>1){printf("%s.md\n", $2)}' $list)"
 
     # Create a link with spaces in target converted to underscores


### PR DESCRIPTION
This PR removes the need to have document numbering in `docs/` (though this can still be used and is needed for older versions).  To use unnumbered docs, use a bulleted list (with `-`)  of names and links in `docs/README.md`. This provides flexibility of how the table of documents appears. Headers can be used within the list, and spaces must be escaped in links.   E.g. an excerpt from IS-04:

```markdown
### Discovery

- [General](Discovery.md)
  - [Registered Operation](Discovery%20-%20Registered%20Operation.md)
  - [Peer to Peer Operation](Discovery%20-%20Peer%20to%20Peer%20Operation.md)

### Behaviour

- [General](Behaviour.md)
```

